### PR TITLE
Add log delegate

### DIFF
--- a/Netcode.IO.NET/Public/Server.cs
+++ b/Netcode.IO.NET/Public/Server.cs
@@ -84,6 +84,11 @@ namespace NetcodeIO.NET
 	public delegate void RemoteClientMessageReceivedEventHandler(RemoteClient sender, byte[] payload, int payloadSize);
 
 	/// <summary>
+	/// Event handler for when the server writes a log message
+	/// </summary>
+	public delegate void ServerLogEventHandler(string message, NetcodeLogLevel logLevel);
+
+	/// <summary>
 	/// Class for starting a Netcode.IO server and accepting connections from remote clients
 	/// </summary>
 	public sealed class Server
@@ -115,6 +120,11 @@ namespace NetcodeIO.NET
 		/// Event triggered when a payload is received from a remote client
 		/// </summary>
 		public event RemoteClientMessageReceivedEventHandler OnClientMessageReceived;
+
+		/// <summary>
+		/// Event triggered when the server logs a message
+		/// </summary>
+		public event ServerLogEventHandler OnLogMessage;
 
 		/// <summary>
 		/// Log level for messages
@@ -304,6 +314,12 @@ namespace NetcodeIO.NET
 			{
 				foreach (var receiver in OnClientMessageReceived.GetInvocationList())
 					OnClientMessageReceived -= (RemoteClientMessageReceivedEventHandler)receiver;
+			}
+
+			if (OnLogMessage != null)
+			{
+				foreach (var receiver in OnLogMessage.GetInvocationList())
+					OnLogMessage -= (ServerLogEventHandler)receiver;
 			}
 		}
 
@@ -1028,7 +1044,8 @@ namespace NetcodeIO.NET
 			if (logLevel > this.LogLevel)
 				return;
 
-			Console.WriteLine(log);
+			if (OnLogMessage != null)
+				OnLogMessage(log, logLevel);
 		}
 
 		private void log(string log, NetcodeLogLevel logLevel, params object[] args)
@@ -1036,7 +1053,8 @@ namespace NetcodeIO.NET
 			if (logLevel > this.LogLevel)
 				return;
 
-			Console.WriteLine(string.Format(log, args));
+			if (OnLogMessage != null)
+				OnLogMessage(string.Format(log, args), logLevel);
 		}
 
 		#endregion

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ server.OnClientDisconnected += clientDisconnectedHandler;	// void( RemoteClient 
 // Called when a payload has been received from a client
 // Note that you should not keep a reference to the payload, as it will be returned to a pool after this call completes.
 server.OnClientMessageRecieved += messageReceivedHandler;	// void( RemoteClient client, byte[] payload, int payloadSize )
+
+// Called when the server logs a message
+// If you are not using a custom logger, a handler using Console.Write() is sufficient.
+server.OnLogMessage += logMessageHandler;			// void( string message, NetcodeLogLevel logLevel )
 ```
 
 To send a payload to a remote client connected to the server:


### PR DESCRIPTION
This is to allow the use of external loggers such as log4net or serilog. Documentation has been updated accordingly.